### PR TITLE
Use the State interface as apparent type for variable declaration

### DIFF
--- a/behavioral/state/state.go
+++ b/behavioral/state/state.go
@@ -40,16 +40,17 @@ func (s *StopState) executeState(c *Context) {
 
 func StateDemo() {
 	context := &Context{}
+	var state State
 
-	startState := &StartState{}
-	startState.executeState(context)
+	state = &StartState{}
+	state.executeState(context)
 	fmt.Println("state: ", context)
 
-	inprState := &InprogressState{}
-	inprState.executeState(context)
+	state = &InprogressState{}
+	state.executeState(context)
 	fmt.Println("state: ", context)
 
-	stopState := &StopState{}
-	stopState.executeState(context)
+	state = &StopState{}
+	state.executeState(context)
 	fmt.Println("state: ", context)
 }


### PR DESCRIPTION
I think this makes a lot more sense in terms of how the state design pattern is actually used. That is, switching the state object as opposed to declaring 3 different states.